### PR TITLE
Update mod for Minecraft 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.10-SNAPSHOT'
+	id 'fabric-loom' version '0.12-SNAPSHOT'
 	id 'maven-publish'
 	id "me.shedaniel.unified-publishing" version "0.1.+"
 }
@@ -12,9 +12,9 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-	maven { url("https://storage.googleapis.com/devan-maven/") }
-	maven { url "https://maven.shedaniel.me/" }
-	maven { url "https://maven.terraformersmc.com/releases/" }
+	maven { url = "https://storage.googleapis.com/devan-maven/" }
+	maven { url = "https://maven.shedaniel.me/" }
+	maven { url = "https://maven.terraformersmc.com/releases/" }
 	// Add repositories to retrieve artifacts from in here.
 	// You should only use this when depending on other mods because
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
@@ -32,9 +32,9 @@ dependencies {
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	include "net.devtech:Stacc:1.3.2"
-	modRuntime(include("net.devtech:Stacc:1.3.2"))
+	modRuntimeOnly(include("net.devtech:Stacc:${project.stacc_version}"))
 
-	modApi("me.shedaniel.cloth:cloth-config-fabric:5.0.38") {
+	modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,17 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.18.2
-	yarn_mappings=1.18.2+build.3
-	loader_version=0.14.5
+	minecraft_version=1.19
+	yarn_mappings=1.19+build.4
+	loader_version=0.14.8
 
 # Mod Properties
-	mod_version = 3.0.0-1.18.2
+	mod_version = 3.0.0-1.19
 	maven_group = io.github.Andrew6rant
 	archives_base_name = stacker
 
 # Dependencies
-	fabric_version=0.51.1+1.18.2
-	modmenu_version=2.0.6
-	cloth_config_version=5.0.34
+	fabric_version=0.56.1+1.19
+	modmenu_version=4.0.0
+	cloth_config_version=7.0.72
+	stacc_version=1.3.4

--- a/src/main/java/io/github/Andrew6rant/stacker/StackerConfig.java
+++ b/src/main/java/io/github/Andrew6rant/stacker/StackerConfig.java
@@ -1,20 +1,11 @@
 package io.github.Andrew6rant.stacker;
 
-import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.annotation.ConfigEntry;
-import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
-import me.shedaniel.clothconfig2.api.ConfigBuilder;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.item.Items;
-import net.minecraft.text.TranslatableText;
-import net.minecraft.util.registry.Registry;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Config(name = "stacker")
 public class StackerConfig implements ConfigData {

--- a/src/main/java/io/github/Andrew6rant/stacker/mixin/ItemRenderScaleMixin.java
+++ b/src/main/java/io/github/Andrew6rant/stacker/mixin/ItemRenderScaleMixin.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Pseudo
 @Mixin(targets = "net.devtech.stacc.ItemCountRenderHandler")
 public class ItemRenderScaleMixin {
-    @Inject(method = "scale", at = @At("RETURN"), cancellable = true)
+    @Inject(method = "scale", at = @At("RETURN"), cancellable = true, remap = false)
     private void forceScale(CallbackInfoReturnable<Float> cir) {
         float intToFloat = (float) (Stacker.getStacker().getStackerConfig().itemCountScaleInt+50)/100;
         if (Stacker.getStacker().getStackerConfig().fontOverride) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "stacker",
-  "version": "3.0.0-1.18.2",
+  "version": "3.0.0-1.19",
 
   "name": "Stacker",
   "description": "Change the stack size of all items!",
@@ -31,13 +31,13 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.11.3",
+    "fabricloader": ">=0.14.6",
     "fabric": "*",
     "minecraft": [
-      "1.18.2"
+      "1.19"
     ],
     "java": ">=17",
-    "cloth-config2": ">=5.0.34"
+    "cloth-config2": ">=7.0.72"
   },
   "custom": {
     "modmenu": [


### PR DESCRIPTION
#### Updated the mod for Minecraft 1.19

I saw you uploaded an "experimental" version supporting 1.19 to Modrinth and Curseforge, but it was 2.1.3 which still used the older version of Stacc. While it did compile and even launch, not much later Sponge threw an ``InjectionError`` from Stacc's ``ClearCommandBugFixin.java`` because the injection targeted pre-1.19 code.

I updated the Stacc version and the gradle build script/settings to properly target 1.19, and also made a little change in ``ItemRenderScaleMixin.java`` at line 19. Sponge complained that injection target 'scale' will not be obfuscated. ``refmap = false`` helped solve this.