### PR TITLE
Feature: Bundle Max Capacity depends on Stacker's maxStacker config option

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ org.gradle.jvmargs=-Xmx1G
 	fabric_version=0.69.1+1.19.3
 	modmenu_version=5.0.0
 	cloth_config_version=9.0.94
-	stacc_version=1.4.0
+	stacc_version=1.5.1

--- a/src/main/java/io/github/Andrew6rant/stacker/Stacker.java
+++ b/src/main/java/io/github/Andrew6rant/stacker/Stacker.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 public class Stacker implements ModInitializer {
 	private static final Logger LOGGER = LogManager.getLogger("Stacker");
 	private static Stacker stacker;
-	static ConfigHolder<StackerConfig> stackerConfig;
+	public static ConfigHolder<StackerConfig> stackerConfig;
 
 	@Override
 	public void onInitialize() {

--- a/src/main/java/io/github/Andrew6rant/stacker/Stacker.java
+++ b/src/main/java/io/github/Andrew6rant/stacker/Stacker.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 public class Stacker implements ModInitializer {
 	private static final Logger LOGGER = LogManager.getLogger("Stacker");
 	private static Stacker stacker;
-	public static ConfigHolder<StackerConfig> stackerConfig;
+	static ConfigHolder<StackerConfig> stackerConfig;
 
 	@Override
 	public void onInitialize() {

--- a/src/main/java/io/github/Andrew6rant/stacker/mixin/BundleItemMixin.java
+++ b/src/main/java/io/github/Andrew6rant/stacker/mixin/BundleItemMixin.java
@@ -1,11 +1,10 @@
 package io.github.Andrew6rant.stacker.mixin;
 
+import io.github.Andrew6rant.stacker.Stacker;
 import net.minecraft.item.BundleItem;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
-
-import static io.github.Andrew6rant.stacker.Stacker.stackerConfig;
 
 /**
  * Modifies BundleItem's magic numbers to use Stacker's configured 'maxStacker' value
@@ -15,31 +14,31 @@ public abstract class BundleItemMixin {
 
     @ModifyConstant(method = "getAmountFilled", constant = @Constant(floatValue = 64.0f))
     private static float replaceAmountFilled(float constant) {
-        return (float) stackerConfig.getConfig().maxStacker;
+        return (float) Stacker.getStacker().getStackerConfig().maxStacker;
     }
 
     @ModifyConstant(method = "onStackClicked", constant = @Constant(intValue = 64))
     private static int replaceOnStackClicked(int constant) {
-        return stackerConfig.getConfig().maxStacker;
+        return Stacker.getStacker().getStackerConfig().maxStacker;
     }
 
     @ModifyConstant(method = "getItemBarStep", constant = @Constant(intValue = 64))
     private static int replaceGetItemBarStep(int constant) {
-        return stackerConfig.getConfig().maxStacker;
+        return Stacker.getStacker().getStackerConfig().maxStacker;
     }
 
     @ModifyConstant(method = "addToBundle", constant = @Constant(intValue = 64))
     private static int replaceAddToBundle(int constant) {
-        return stackerConfig.getConfig().maxStacker;
+        return Stacker.getStacker().getStackerConfig().maxStacker;
     }
 
     @ModifyConstant(method = "getItemOccupancy", constant = @Constant(intValue = 64))
     private static int replaceGetItemOccupancy(int constant) {
-        return stackerConfig.getConfig().maxStacker;
+        return Stacker.getStacker().getStackerConfig().maxStacker;
     }
 
     @ModifyConstant(method = "appendTooltip", constant = @Constant(intValue = 64))
     private static int replaceAppendTooltip(int constant) {
-        return stackerConfig.getConfig().maxStacker;
+        return Stacker.getStacker().getStackerConfig().maxStacker;
     }
 }

--- a/src/main/java/io/github/Andrew6rant/stacker/mixin/BundleItemMixin.java
+++ b/src/main/java/io/github/Andrew6rant/stacker/mixin/BundleItemMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import static io.github.Andrew6rant.stacker.Stacker.stackerConfig;
 
 /**
- * Mixin class used to modify vanilla's magic numbers to use this mod's configured 'maxStacker' value
+ * Modifies BundleItem's magic numbers to use Stacker's configured 'maxStacker' value
  */
 @Mixin(BundleItem.class)
 public abstract class BundleItemMixin {

--- a/src/main/java/io/github/Andrew6rant/stacker/mixin/BundleItemMixin.java
+++ b/src/main/java/io/github/Andrew6rant/stacker/mixin/BundleItemMixin.java
@@ -1,0 +1,45 @@
+package io.github.Andrew6rant.stacker.mixin;
+
+import net.minecraft.item.BundleItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import static io.github.Andrew6rant.stacker.Stacker.stackerConfig;
+
+/**
+ * Mixin class used to modify vanilla's magic numbers to use this mod's configured 'maxStacker' value
+ */
+@Mixin(BundleItem.class)
+public abstract class BundleItemMixin {
+
+    @ModifyConstant(method = "getAmountFilled", constant = @Constant(floatValue = 64.0f))
+    private static float replaceAmountFilled(float constant) {
+        return (float) stackerConfig.getConfig().maxStacker;
+    }
+
+    @ModifyConstant(method = "onStackClicked", constant = @Constant(intValue = 64))
+    private static int replaceOnStackClicked(int constant) {
+        return stackerConfig.getConfig().maxStacker;
+    }
+
+    @ModifyConstant(method = "getItemBarStep", constant = @Constant(intValue = 64))
+    private static int replaceGetItemBarStep(int constant) {
+        return stackerConfig.getConfig().maxStacker;
+    }
+
+    @ModifyConstant(method = "addToBundle", constant = @Constant(intValue = 64))
+    private static int replaceAddToBundle(int constant) {
+        return stackerConfig.getConfig().maxStacker;
+    }
+
+    @ModifyConstant(method = "getItemOccupancy", constant = @Constant(intValue = 64))
+    private static int replaceGetItemOccupancy(int constant) {
+        return stackerConfig.getConfig().maxStacker;
+    }
+
+    @ModifyConstant(method = "appendTooltip", constant = @Constant(intValue = 64))
+    private static int replaceAppendTooltip(int constant) {
+        return stackerConfig.getConfig().maxStacker;
+    }
+}

--- a/src/main/resources/stacker.mixins.json
+++ b/src/main/resources/stacker.mixins.json
@@ -13,7 +13,8 @@
     "JukeboxBlockMixin",
     "LimitFurnaceStackMixin",
     "MilkBucketItemMixin",
-    "StewItemMixin"
+    "StewItemMixin",
+    "BundleItemMixin"
   ],
   "client": [
     "ItemRenderScaleMixin"


### PR DESCRIPTION
Targets branch `1.19.x`
Implements #50

**Changes:**
Updates Stacc dependency 1.4.0 -> 1.5.1
Adds `BundleItemMixin`, which modifies magic number constants used in `BundleItem` to match Stacker's maxStacker config value. 

_Note that `BundleItem` contains a constant `MAX_STORAGE` that is completely unused by Mojang. If it becomes used in a future update, the `BundleItemMixin` will need to be updated, but will be condensed significantly as well._