### PR TITLE
Updated to 1.19.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ bin/
 # fabric
 
 run/
+
+/remappedSrc/

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,17 @@ repositories {
 	maven { url = "https://storage.googleapis.com/devan-maven/" }
 	maven { url = "https://maven.shedaniel.me/" }
 	maven { url = "https://maven.terraformersmc.com/releases/" }
-
+	exclusiveContent {
+		forRepository {
+			maven {
+				name = "Modrinth"
+				url = "https://api.modrinth.com/maven"
+			}
+		}
+		filter {
+			includeGroup "maven.modrinth"
+		}
+	}
 	// Add repositories to retrieve artifacts from in here.
 	// You should only use this when depending on other mods because
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
@@ -33,13 +43,17 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	include "net.devtech:Stacc:${project.stacc_version}"
-	modRuntimeOnly(include("net.devtech:Stacc:${project.stacc_version}"))
+	//include "net.devtech:Stacc:${project.stacc_version}"
+	//modRuntimeOnly(include("net.devtech:Stacc:${project.stacc_version}"))
+
+	include "maven.modrinth:stacc-api:${project.stacc_version}"
+	modRuntimeOnly(include "maven.modrinth:stacc-api:${project.stacc_version}")
 
 	modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
 
+	modRuntimeOnly("com.terraformersmc:modmenu:${project.modmenu_version}")
 	modCompileOnly("com.terraformersmc:modmenu:${project.modmenu_version}") {
 		transitive = false
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.19.3
-	yarn_mappings=1.19.3+build.3
-	loader_version=0.14.11
+	minecraft_version=1.19.4
+	yarn_mappings=1.19.4+build.2
+	loader_version=0.14.19
 
 # Mod Properties
-	mod_version = 3.0.2-1.19.3
+	mod_version = 3.1.0-1.19.4
 	maven_group = io.github.Andrew6rant
 	archives_base_name = stacker
 
 # Dependencies
-	fabric_version=0.69.1+1.19.3
-	modmenu_version=5.0.0
-	cloth_config_version=9.0.94
-	stacc_version=1.5.1
+	fabric_version=0.76.0+1.19.4
+	modmenu_version=6.1.0-rc.4
+	cloth_config_version=10.0.96
+	stacc_version=1.5.2

--- a/src/main/java/io/github/Andrew6rant/stacker/mixin/MusicDiscItemMixin.java
+++ b/src/main/java/io/github/Andrew6rant/stacker/mixin/MusicDiscItemMixin.java
@@ -1,19 +1,18 @@
 package io.github.Andrew6rant.stacker.mixin;
 
-import net.minecraft.block.JukeboxBlock;
 import net.minecraft.block.entity.JukeboxBlockEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.MusicDiscItem;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-@Mixin(JukeboxBlock.class)
-public class JukeboxBlockMixin {
-    // Credit to ZoeyTheEgoist for this mixin
-    @Redirect(method = "setRecord", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/entity/JukeboxBlockEntity;setRecord(Lnet/minecraft/item/ItemStack;)V"))
+@Mixin(MusicDiscItem.class)
+public class MusicDiscItemMixin {
+    @Redirect(method = "useOnBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/entity/JukeboxBlockEntity;setStack(Lnet/minecraft/item/ItemStack;)V"))
     public void setCountToOne(JukeboxBlockEntity jukeboxBlockEntity, ItemStack stack) {
         ItemStack newStack = stack.copy();
         newStack.setCount(1);
-        jukeboxBlockEntity.setRecord(newStack);
+        jukeboxBlockEntity.setStack(newStack);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,13 +31,13 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.14.6",
+    "fabricloader": ">=0.14.8",
     "fabric": "*",
     "minecraft": [
-      "1.19.3"
+      "1.19.4"
     ],
     "java": ">=17",
-    "cloth-config2": ">=9.0.94"
+    "cloth-config2": ">=10.0.0"
   },
   "custom": {
     "modmenu": [

--- a/src/main/resources/stacker.mixins.json
+++ b/src/main/resources/stacker.mixins.json
@@ -6,15 +6,15 @@
   "mixins": [
     "AnvilScreenHandlerMixin",
     "BucketItemMixin",
+    "BundleItemMixin",
     "DispenserBehaviorMixin",
     "HorseScreenHandlerMixin",
     "ItemAccess",
     "ItemStackMixin",
-    "JukeboxBlockMixin",
     "LimitFurnaceStackMixin",
     "MilkBucketItemMixin",
-    "StewItemMixin",
-    "BundleItemMixin"
+    "MusicDiscItemMixin",
+    "StewItemMixin"
   ],
   "client": [
     "ItemRenderScaleMixin"


### PR DESCRIPTION
# Changes
- Updated to 1.19.4!
- For some reason, stacc-api original maven repo was broken at the time I was coding so I decided to swapped it for build from Modrinth Maven. Feel free to go back to the original repo once that's back up.
- `JukeBoxBlock`'s `setRecord` no longer exists; it had been replace with `JukeBoxBlockEntity.setStack` as there's been an update to Jukeboxi n 1.19.4. One mixin had been accommodated for this change